### PR TITLE
fix: Resolve IDisposable memory leaks in image source strategies

### DIFF
--- a/src/MetaExtractor.Infrastructure/Services/CameraImageSourceStrategy.cs
+++ b/src/MetaExtractor.Infrastructure/Services/CameraImageSourceStrategy.cs
@@ -82,6 +82,7 @@ public class CameraImageSourceStrategy : IImageSourceStrategy, IDisposable
 
         if (frame.Empty())
         {
+            frame.Dispose();
             return Task.FromResult<Mat?>(null);
         }
 

--- a/src/MetaExtractor.Infrastructure/Services/FileImageSourceStrategy.cs
+++ b/src/MetaExtractor.Infrastructure/Services/FileImageSourceStrategy.cs
@@ -61,6 +61,7 @@ public class FileImageSourceStrategy : IImageSourceStrategy, IDisposable
 
         if (frame.Empty())
         {
+            frame.Dispose();
             return Task.FromResult<Mat?>(null);
         }
 
@@ -76,13 +77,15 @@ public class FileImageSourceStrategy : IImageSourceStrategy, IDisposable
         }
 
         _isImageRead = true;
-        
+
+        Mat? mat = null;
         try
         {
-            var mat = new Mat(_filePath, ImreadModes.Color);
+            mat = new Mat(_filePath, ImreadModes.Color);
 
             if (mat.Empty())
             {
+                mat.Dispose();
                 return Task.FromResult<Mat?>(null);
             }
 
@@ -90,6 +93,7 @@ public class FileImageSourceStrategy : IImageSourceStrategy, IDisposable
         }
         catch (Exception)
         {
+            mat?.Dispose();
             return Task.FromResult<Mat?>(null);
         }
     }


### PR DESCRIPTION
## Summary
- Fix Mat object disposal in FileImageSourceStrategy when empty frames/images
- Fix Mat object disposal in CameraImageSourceStrategy when empty frames  
- Add proper exception handling with disposal in GetImageFrameAsync
- Prevents OpenCV Mat memory leaks identified by CodeQL analysis

## Changes Made
### FileImageSourceStrategy.cs
- Added `frame.Dispose()` in `GetNextVideoFrameAsync()` when frame is empty
- Added `mat.Dispose()` in `GetImageFrameAsync()` when mat is empty
- Added proper exception handling with `mat?.Dispose()` in catch block

### CameraImageSourceStrategy.cs
- Added `frame.Dispose()` in `GetNextFrameAsync()` when frame is empty

## Test Plan
- [x] Build successful (no compilation errors)
- [x] All existing tests pass (53/53)
- [x] Memory leak scenarios properly handled
- [x] No breaking changes to existing functionality

## Resolves
Fixes #35 - CodeQL IDisposable 미처리 문제 해결

🤖 Generated with [Claude Code](https://claude.ai/code)